### PR TITLE
chore: fix docs description header

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,4 +1,4 @@
-# Description
+## Description
 
 This plugin uses [Grafana k6](https://k6.io/) to run performance tests in a Vela pipeline.
 


### PR DESCRIPTION
The Description header should only be level 2, as the [official documentation](https://go-vela.github.io/docs/plugins/registry/pipeline/k6/) adds its own level 1 header.
The `mdl` make directive has been modified to ignore this for `DOCS.md`