### PR TITLE
chore(license): update source code headers + copyright year

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -26,9 +26,9 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 ## Copyright and License
 
 ```text
-Copyright (c) 2023 Target Brands, Inc.
+Copyright 2023 Target Brands, Inc.
 ```
 
 The Grafana Labs Marks are trademarks of Grafana Labs, and are used with Grafana Labs’ permission. We are not affiliated with, endorsed or sponsored by Grafana Labs or its affiliates.
 
-[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[Apache License, Version 2.0](../LICENSE)

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright (c) 2023 Target Brands, Inc.
+Copyright 2023 Target Brands, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
ref: https://github.com/go-vela/community/issues/747

- replaces code file license headers with SPDX header (see https://spdx.dev/ids/#why); this removes copyright + year
- update golangci-lint rule to ensure code file enforcement
- use first commit date for copyright year and updates year in other select places
- format is changed to match "Copyright [yyyy] [name of copyright owner]" as shown here: https://www.apache.org/licenses/LICENSE-2.0.html
