### PR TITLE
Making compatible with golangci-lint v2

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -24,7 +24,7 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2
+        uses: reviewdog/action-golangci-lint@3dfdce20f5ca12d264c214abb993dbb40834da90 # v2.7.2
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--config=.golangci.yml"
@@ -48,7 +48,7 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2
+        uses: reviewdog/action-golangci-lint@3dfdce20f5ca12d264c214abb993dbb40834da90 # v2.7.2
         with:
           github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--config=.golangci.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage.out
+          exclude: cmd/vela-k6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,150 +1,74 @@
 ---
-# This is a manually created golangci.com yaml configuration with
-# some defaults explicitly provided. There is a large number of
-# linters we've enabled that are usually disabled by default.
-#
-# https://golangci-lint.run/usage/configuration/#config-file
-
-# This section provides the configuration for how golangci
-# outputs it results from the linters it executes.
-output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
-# This section provides the configuration for each linter
-# we've instructed golangci to execute.
-linters-settings:
-  # https://github.com/mibk/dupl
-  dupl:
-    threshold: 100
-
-  # https://github.com/ultraware/funlen
-  funlen:
-    # accounting for comments
-    lines: 160
-    statements: 70
-
-  # https://github.com/client9/misspell
-  misspell:
-    locale: US
-
-  # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
-  nolintlint:
-    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space)
-    allow-unused: false # allow nolint directives that don't address a linting issue
-    require-explanation: true # require an explanation for nolint directives
-    require-specific: true # require nolint directives to be specific about which linter is being skipped
-
-# This section provides the configuration for which linters
-# golangci will execute. Several of them were disabled by
-# default but we've opted to enable them.
+version: "2"
 linters:
-  # disable all linters as new linters might be added to golangci
-  disable-all: true
-
-  # enable a specific set of linters to run
+  default: none
   enable:
-    - bidichk # checks for dangerous unicode character sequences
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - contextcheck # check the function whether use a non-inherited context
-    - dupl # code clone detection
-    - errcheck # checks for unchecked errors
-    - errorlint # find misuses of errors
-    - exportloopref # check for exported loop vars
-    - funlen # detects long functions
-    - goconst # finds repeated strings that could be replaced by a constant
-    - gocyclo # computes and checks the cyclomatic complexity of functions
-    - godot # checks if comments end in a period
-    - gofmt # checks whether code was gofmt-ed
-    - goheader # checks is file header matches to pattern
-    - goimports # fixes imports and formats code in same style as gofmt
-    - gomoddirectives # manage the use of 'replace', 'retract', and 'excludes' directives in go.mod
-    - goprintffuncname # checks that printf-like functions are named with f at the end
-    - gosec # inspects code for security problems
-    - gosimple # linter that specializes in simplifying a code
-    - govet # reports suspicious constructs, ex. Printf calls whose arguments don't align with the format string
-    - ineffassign # detects when assignments to existing variables aren't used
-    - makezero # finds slice declarations with non-zero initial length
-    - misspell # finds commonly misspelled English words in comments
-    - nakedret # finds naked returns in functions greater than a specified function length
-    - nilerr # finds the code that returns nil even if it checks that the error is not nil
-    - noctx # noctx finds sending http request without context.Context
-    - nolintlint # reports ill-formed or insufficient nolint directives
-    - revive # linter for go
-    - staticcheck # applies static analysis checks, go vet on steroids
-    - stylecheck # replacement for golint
-    - tenv # analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
-    - typecheck # parses and type-checks go code, like the front-end of a go compiler
-    - unconvert # remove unnecessary type conversions
-    - unparam # reports unused function parameters
-    - unused # checks for unused constants, variables, functions and types
-    - whitespace # detects leading and trailing whitespace
-    - wsl # forces code to use empty lines
-
-    # static list of linters we know golangci can run but we've
-    # chosen to leave disabled for now
-    # - asciicheck          - non-critical
-    # - cyclop              - unused complexity metric
-    # - depguard            - unused
-    # - dogsled             - blanks allowed
-    # - durationcheck       - unused
-    # - errname             - unused
-    # - exhaustive          - unused
-    # - exhaustivestruct    - style preference
-    # - forbidigo           - unused
-    # - forcetypeassert     - unused
-    # - gci                 - use goimports
-    # - gochecknoinits      - unused
-    # - gochecknoglobals    - global variables allowed
-    # - gocognit            - unused complexity metric
-    # - gocritic            - style preference
-    # - godox               - to be used in the future
-    # - goerr113            - to be used in the future
-    # - golint              - archived, replaced with revive
-    # - gofumpt             - use gofmt
-    # - gomnd               - get too many false-positives
-    # - gomodguard          - unused
-    # - ifshort             - use both styles
-    # - ireturn             - allow interfaces to be returned
-    # - importas            - want flexibility with naming
-    # - lll                 - not too concerned about line length
-    # - interfacer          - archived
-    # - nestif              - non-critical
-    # - nilnil              - style preference
-    # - nlreturn            - style preference
-    # - maligned            - archived, replaced with govet 'fieldalignment'
-    # - paralleltest        - false-positives
-    # - prealloc            - don't use
-    # - predeclared         - unused
-    # - promlinter          - style preference
-    # - rowserrcheck        - unused
-    # - scopelint           - deprecated - replaced with exportloopref
-    # - sqlclosecheck       - unused
-    # - tagliatelle         - use a mix of variable naming
-    # - testpackage         - don't use this style of testing
-    # - thelper             - false-positives
-    # - varnamelen          - unused
-    # - wastedassign        - duplicate functionality
-    # - wrapcheck           - style preference
-
-# This section provides the configuration for how golangci
-# will report the issues it finds.
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # prevent linters from running on *_test.go files
-    - path: _test\.go
-      linters:
-        - dupl
-        - funlen
-        - goconst
-        - gocyclo
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - dupl
+    - errcheck
+    - errorlint
+    - funlen
+    - goconst
+    - gocyclo
+    - godot
+    - goheader
+    - gomoddirectives
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nilerr
+    - noctx
+    - nolintlint
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+    - wsl
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 160
+      statements: 70
+    misspell:
+      locale: US
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-unused: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - funlen
+          - goconst
+          - gocyclo
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,74 +1,162 @@
 ---
+# This is a manually created golangci.com yaml configuration with
+# some defaults explicitly provided. There is a large number of
+# linters we've enabled that are usually disabled by default.
+#
+# https://golangci-lint.run/usage/configuration/#config-file
+
+# This section provides the configuration for how golangci
+# outputs it results from the linters it executes.
 version: "2"
+output:
+  formats:
+    text: 
+      print-issued-lines: true # print lines of code with issue, default is true
+      colors: true # print output in color, default is true
+      print-linter-name: true # print linter name in the end of issue text, default is true
+
+# This section provides the configuration for which linters
+# golangci will execute. Several of them were disabled by
+# default but we've opted to enable them.
 linters:
-  default: none
+  # disable all linters as new linters might be added to golangci
+  disable-all: true
+
+  # enable a specific set of linters to run
   enable:
-    - bidichk
-    - bodyclose
-    - contextcheck
-    - dupl
-    - errcheck
-    - errorlint
-    - funlen
-    - goconst
-    - gocyclo
-    - godot
-    - goheader
-    - gomoddirectives
-    - goprintffuncname
-    - gosec
-    - govet
-    - ineffassign
-    - makezero
-    - misspell
-    - nakedret
-    - nilerr
-    - noctx
-    - nolintlint
-    - revive
-    - staticcheck
-    - unconvert
-    - unparam
-    - unused
-    - whitespace
-    - wsl
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - contextcheck # check the function whether use a non-inherited context
+    - copyloopvar # detects places where loop variables are copied
+    - dupl # code clone detection
+    - errcheck # checks for unchecked errors
+    - errorlint # find misuses of errors
+    - funlen # detects long functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godot # checks if comments end in a period
+    - goheader # checks is file header matches to pattern
+    - gomoddirectives # manage the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects code for security problems
+    - govet # reports suspicious constructs, ex. Printf calls whose arguments don't align with the format string
+    - ineffassign # detects when assignments to existing variables aren't used
+    - makezero # finds slice declarations with non-zero initial length
+    - misspell # finds commonly misspelled English words in comments
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - noctx # noctx finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - revive # linter for go
+    - staticcheck # applies static analysis checks, go vet on steroids
+    - unconvert # remove unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unused # checks for unused constants, variables, functions and types
+    - usetesting # checks to make sure to use testing specific helpers
+    - whitespace # detects leading and trailing whitespace
+    - wsl # forces code to use empty lines
+
+  # static list of linters we know golangci can run but we've
+  # chosen to leave disabled for now
+  # - asciicheck          - non-critical
+  # - cyclop              - unused complexity metric
+  # - depguard            - unused
+  # - dogsled             - blanks allowed
+  # - durationcheck       - unused
+  # - errname             - unused
+  # - exhaustive          - unused
+  # - exhaustivestruct    - style preference
+  # - forbidigo           - unused
+  # - forcetypeassert     - unused
+  # - gochecknoinits      - unused
+  # - gochecknoglobals    - global variables allowed
+  # - gocognit            - unused complexity metric
+  # - gocritic            - style preference
+  # - godox               - to be used in the future
+  # - goerr113            - to be used in the future
+  # - goimports           - use gci
+  # - golint              - archived, replaced with revive
+  # - gofumpt             - use gofmt
+  # - gomnd               - get too many false-positives
+  # - gomodguard          - unused
+  # - ifshort             - use both styles
+  # - ireturn             - allow interfaces to be returned
+  # - importas            - want flexibility with naming
+  # - lll                 - not too concerned about line length
+  # - interfacer          - archived
+  # - nestif              - non-critical
+  # - nilnil              - style preference
+  # - nlreturn            - style preference
+  # - maligned            - archived, replaced with govet 'fieldalignment'
+  # - paralleltest        - false-positives
+  # - prealloc            - don't use
+  # - predeclared         - unused
+  # - promlinter          - style preference
+  # - rowserrcheck        - unused
+  # - scopelint           - deprecated - replaced with exportloopref
+  # - sqlclosecheck       - unused
+  # - tagliatelle         - use a mix of variable naming
+  # - testpackage         - don't use this style of testing
+  # - thelper             - false-positives
+  # - varnamelen          - unused
+  # - wastedassign        - duplicate functionality
+  # - wrapcheck           - style preference
+
   settings:
+    # https://github.com/karamaru-alpha/copyloopvar
+    copyloopvar:
+      check-alias: true
+
+    # https://github.com/mibk/dupl
     dupl:
       threshold: 100
+
+    # https://github.com/ultraware/funlen
     funlen:
+      # accounting for comments
       lines: 160
       statements: 70
+
+    # https://github.com/daixiang0/gci
+    # ensure import order is consistent
+    # gci write --custom-order -s standard -s default -s blank -s dot -s "prefix(github.com/go-vela)" .
+    gci:
+      custom-order: true
+      sections:
+        - standard
+        - default
+        - blank
+        - dot
+        - prefix(github.com/go-vela)
+
+    # https://github.com/denis-tingaikin/go-header
+    goheader:
+      template: |-
+        SPDX-License-Identifier: Apache-2.0
+
+    # https://github.com/client9/misspell
     misspell:
       locale: US
+
+    # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
     nolintlint:
-      require-explanation: true
-      require-specific: true
-      allow-unused: false
-  exclusions:
-    generated: lax
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
-    rules:
-      - linters:
-          - dupl
-          - funlen
-          - goconst
-          - gocyclo
-        path: _test\.go
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
-formatters:
-  enable:
-    - gofmt
-    - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+      allow-unused: false # allow nolint directives that don't address a linting issue
+      require-explanation: true # require an explanation for nolint directives
+      require-specific: true # require nolint directives to be specific about which linter is being skipped
+
+
+# This section provides the configuration for how golangci
+# will report the issues it finds.
+issues:
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # prevent linters from running on *_test.go files
+    - path: _test\.go
+      linters:
+        - dupl
+        - funlen
+        - goconst
+        - gocyclo
+        - wsl

--- a/DOCS.md
+++ b/DOCS.md
@@ -1,10 +1,10 @@
-## Description
+# Description
 
 This plugin uses [Grafana k6](https://k6.io/) to run performance tests in a Vela pipeline.
 
-Source Code: https://github.com/go-vela/vela-k6
+Source Code: <https://github.com/go-vela/vela-k6>
 
-Registry: https://hub.docker.com/r/target/vela-k6
+Registry: <https://hub.docker.com/r/target/vela-k6>
 
 ## Usage
 

--- a/cmd/vela-k6/main.go
+++ b/cmd/vela-k6/main.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is the entry point for the Vela K6 plugin.
+// It captures the version information, configures the plugin from environment variables,
+// runs the setup script, and executes performance tests.
 package main
 
 import (
@@ -24,7 +29,7 @@ func main() {
 	}
 
 	// output the version information to stdout
-	fmt.Fprintf(os.Stdout, "%s\n", string(bytes))
+	_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(bytes))
 
 	p := plugin.New()
 	if err = p.ConfigFromEnv(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-vela/vela-k6
 
-go 1.23.5
+go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/plugin/mock/plugin.go
+++ b/plugin/mock/plugin.go
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mock provides mock implementations of the types.ShellCommand interface
+// and a mock ThresholdError that simulates a threshold breach error.
 package mock
 
 import (
@@ -10,6 +14,7 @@ import (
 
 const thresholdsBreachedExitCode = 99
 
+// Command is a mock implementation of the types.ShellCommand interface.
 type Command struct {
 	args          []string
 	waitErr       error
@@ -18,23 +23,28 @@ type Command struct {
 	startErr      error
 }
 
+// Start is a mock implementation of the Start method.
 func (m *Command) Start() error {
 	return m.startErr
 }
 
+// Wait is a mock implementation of the Wait method.
 func (m *Command) Wait() error {
 	return m.waitErr
 }
 
+// String is a mock implementation of the String method.
 func (m *Command) String() (str string) {
 	return ""
 }
 
+// StdoutPipe is a mock implementation of the StdoutPipe method.
 func (m *Command) StdoutPipe() (io.ReadCloser, error) {
 	dummyReader := strings.NewReader("")
 	return io.NopCloser(dummyReader), m.stdoutPipeErr
 }
 
+// StderrPipe is a mock implementation of the StderrPipe method.
 func (m *Command) StderrPipe() (io.ReadCloser, error) {
 	dummyReader := strings.NewReader("")
 	return io.NopCloser(dummyReader), m.stderrPipeErr
@@ -54,14 +64,18 @@ func CommandBuilderWithError(waitErr error, stdoutPipeErr error, stderrPipeErr e
 	}
 }
 
+// ThresholdError is a mock implementation of the exec.ExitError interface
+// that simulates a threshold breach error.
 type ThresholdError struct {
 	exec.ExitError
 }
 
+// ExitCode returns the exit code for the mock threshold breach error.
 func (m *ThresholdError) ExitCode() int {
 	return thresholdsBreachedExitCode
 }
 
+// Error returns a string representation of the mock threshold breach error.
 func (m *ThresholdError) Error() string {
 	return "This is a mock threshold breach error"
 }

--- a/plugin/mock/plugin_test.go
+++ b/plugin/mock/plugin_test.go
@@ -50,7 +50,7 @@ func TestStderrPipe(t *testing.T) {
 }
 
 func TestCommandBuilderWithError(t *testing.T) {
-	result := CommandBuilderWithError(errors.New("some error"))
+	result := CommandBuilderWithError(errors.New("some error"), nil, nil, nil)
 	assert.ErrorContains(t, result("start").Wait(), "some error")
 }
 

--- a/plugin/mock/plugin_test.go
+++ b/plugin/mock/plugin_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package mock
 
 import (

--- a/plugin/mock/plugin_test.go
+++ b/plugin/mock/plugin_test.go
@@ -50,7 +50,7 @@ func TestStderrPipe(t *testing.T) {
 }
 
 func TestCommandBuilderWithError(t *testing.T) {
-	result := CommandBuilderWithError(errors.New("some error"), nil, nil, nil)
+	result := CommandBuilderWithError(errors.New("some error"))
 	assert.ErrorContains(t, result("start").Wait(), "some error")
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package plugin provides the implementation of the Vela K6 plugin.
 package plugin
 
 import (
@@ -24,12 +27,16 @@ type pluginType struct {
 	verifyFileExists func(path string) error                              // verifyFileExists can be swapped out for a mock function for unit testing.
 }
 
+// Plugin is the interface that defines the methods for the Vela K6 plugin.
 type Plugin interface {
 	ConfigFromEnv() error
 	RunSetupScript() error
 	RunPerfTests() error
 }
 
+// New returns a new instance of the Vela K6 plugin with default
+// implementations for buildCommand and verifyFileExists. This allows
+// for easy mocking in unit tests.
 func New() Plugin {
 	return &pluginType{
 		buildCommand:     buildExecCommand,

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package plugin
 
 import (
@@ -40,30 +42,6 @@ func TestSanitizeScriptPath(t *testing.T) {
 		assert.Equal(t, "file-dash_underscore.js", sanitizeScriptPath("file-dash_underscore.js"))
 		assert.Equal(t, "path/to/file.js", sanitizeScriptPath("path/to/file.js"))
 		assert.Equal(t, "/path/to/file.js", sanitizeScriptPath("/path/to/file.js"))
-	})
-
-	t.Run("Invalid Filepaths", func(t *testing.T) {
-		t.Parallel()
-
-		assert.Equal(t, "", sanitizeScriptPath(".../file.js"))
-		assert.Equal(t, "", sanitizeScriptPath("./../file.js"))
-		assert.Equal(t, "", sanitizeScriptPath("*/file.js"))
-		assert.Equal(t, "", sanitizeScriptPath(".file.js"))
-		assert.Equal(t, "", sanitizeScriptPath("/.js"))
-		assert.Equal(t, "", sanitizeScriptPath("-.js"))
-		assert.Equal(t, "", sanitizeScriptPath("_.js"))
-		assert.Equal(t, "", sanitizeScriptPath("_invalid$name.js"))
-		assert.Equal(t, "", sanitizeScriptPath("invalid$name.js"))
-		assert.Equal(t, "", sanitizeScriptPath("invalidformat.png"))
-		assert.Equal(t, "", sanitizeScriptPath("file.js; rm -rf /"))
-		assert.Equal(t, "", sanitizeScriptPath("file.js && suspicious-call"))
-	})
-}
-
-func TestSanitizeOutputPath(t *testing.T) {
-	t.Run("Valid Filepaths", func(t *testing.T) {
-		t.Parallel()
-
 		assert.Equal(t, "file.json", sanitizeOutputPath("file.json"))
 		assert.Equal(t, "./file.json", sanitizeOutputPath("./file.json"))
 		assert.Equal(t, "../file.json", sanitizeOutputPath("../file.json"))
@@ -76,18 +54,30 @@ func TestSanitizeOutputPath(t *testing.T) {
 	t.Run("Invalid Filepaths", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Equal(t, "", sanitizeOutputPath(".../file.json"))
-		assert.Equal(t, "", sanitizeOutputPath("./../file.json"))
-		assert.Equal(t, "", sanitizeOutputPath("*/file.json"))
-		assert.Equal(t, "", sanitizeOutputPath(".file.json"))
-		assert.Equal(t, "", sanitizeOutputPath("/.json"))
-		assert.Equal(t, "", sanitizeOutputPath("-.json"))
-		assert.Equal(t, "", sanitizeOutputPath("_.json"))
-		assert.Equal(t, "", sanitizeOutputPath("_invalid$name.json"))
-		assert.Equal(t, "", sanitizeOutputPath("invalid$name.json"))
-		assert.Equal(t, "", sanitizeOutputPath("invalidformat.png"))
-		assert.Equal(t, "", sanitizeOutputPath("file.json; rm -rf /"))
-		assert.Equal(t, "", sanitizeOutputPath("file.json && suspicious-call"))
+		assert.Empty(t, sanitizeScriptPath(".../file.js"))
+		assert.Empty(t, sanitizeScriptPath("./../file.js"))
+		assert.Empty(t, sanitizeScriptPath("*/file.js"))
+		assert.Empty(t, sanitizeScriptPath(".file.js"))
+		assert.Empty(t, sanitizeScriptPath("/.js"))
+		assert.Empty(t, sanitizeScriptPath("-.js"))
+		assert.Empty(t, sanitizeScriptPath("_.js"))
+		assert.Empty(t, sanitizeScriptPath("_invalid$name.js"))
+		assert.Empty(t, sanitizeScriptPath("invalid$name.js"))
+		assert.Empty(t, sanitizeScriptPath("invalidformat.png"))
+		assert.Empty(t, sanitizeScriptPath("file.js; rm -rf /"))
+		assert.Empty(t, sanitizeScriptPath("file.js && suspicious-call"))
+		assert.Empty(t, sanitizeOutputPath(".../file.json"))
+		assert.Empty(t, sanitizeOutputPath("./../file.json"))
+		assert.Empty(t, sanitizeOutputPath("*/file.json"))
+		assert.Empty(t, sanitizeOutputPath(".file.json"))
+		assert.Empty(t, sanitizeOutputPath("/.json"))
+		assert.Empty(t, sanitizeOutputPath("-.json"))
+		assert.Empty(t, sanitizeOutputPath("_.json"))
+		assert.Empty(t, sanitizeOutputPath("_invalid$name.json"))
+		assert.Empty(t, sanitizeOutputPath("invalid$name.json"))
+		assert.Empty(t, sanitizeOutputPath("invalidformat.png"))
+		assert.Empty(t, sanitizeOutputPath("file.json; rm -rf /"))
+		assert.Empty(t, sanitizeOutputPath("file.json && suspicious-call"))
 	})
 }
 
@@ -107,18 +97,18 @@ func TestSanitizeSetupPath(t *testing.T) {
 	t.Run("Invalid Filepaths", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Equal(t, "", sanitizeSetupPath(".../file.sh"))
-		assert.Equal(t, "", sanitizeSetupPath("./../file.sh"))
-		assert.Equal(t, "", sanitizeSetupPath("*/file.sh"))
-		assert.Equal(t, "", sanitizeSetupPath(".file.sh"))
-		assert.Equal(t, "", sanitizeSetupPath("/.sh"))
-		assert.Equal(t, "", sanitizeSetupPath("-.sh"))
-		assert.Equal(t, "", sanitizeSetupPath("_.sh"))
-		assert.Equal(t, "", sanitizeSetupPath("_invalid$name.sh"))
-		assert.Equal(t, "", sanitizeSetupPath("invalid$name.sh"))
-		assert.Equal(t, "", sanitizeSetupPath("invalidformat.png"))
-		assert.Equal(t, "", sanitizeSetupPath("file.sh; rm -rf /"))
-		assert.Equal(t, "", sanitizeSetupPath("file.sh && suspicious-call"))
+		assert.Empty(t, sanitizeSetupPath(".../file.sh"))
+		assert.Empty(t, sanitizeSetupPath("./../file.sh"))
+		assert.Empty(t, sanitizeSetupPath("*/file.sh"))
+		assert.Empty(t, sanitizeSetupPath(".file.sh"))
+		assert.Empty(t, sanitizeSetupPath("/.sh"))
+		assert.Empty(t, sanitizeSetupPath("-.sh"))
+		assert.Empty(t, sanitizeSetupPath("_.sh"))
+		assert.Empty(t, sanitizeSetupPath("_invalid$name.sh"))
+		assert.Empty(t, sanitizeSetupPath("invalid$name.sh"))
+		assert.Empty(t, sanitizeSetupPath("invalidformat.png"))
+		assert.Empty(t, sanitizeSetupPath("file.sh; rm -rf /"))
+		assert.Empty(t, sanitizeSetupPath("file.sh && suspicious-call"))
 	})
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -1,7 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package types defines interfaces and types used in the Vela K6 plugin.
 package types
 
 import "io"
 
+// ShellCommand is an interface that defines the methods for executing shell commands.
 type ShellCommand interface {
 	Start() error
 	Wait() error
@@ -10,6 +14,7 @@ type ShellCommand interface {
 	String() string
 }
 
+// ErrorWithExitCode is an interface that defines a method for retrieving an exit code from an error.
 type ErrorWithExitCode interface {
 	ExitCode() int
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package version provides the version information for the Vela application.
 package version
 
 import (

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (
@@ -8,15 +10,21 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	const (
+		goVersion   = "go1.20.7"
+		osVersion   = "darwin"
+		archVersion = "arm64"
+	)
+
 	t.Run("Valid Version Output", func(t *testing.T) {
 		// to avoid flaky tests, set the values
-		Go = "go1.20.7"
-		OS = "darwin"
+		Go = goVersion
+		OS = osVersion
 		Compiler = "gc"
 		Tag = "v1.1.1"
 		Commit = "000"
 		Date = "111"
-		Arch = "arm64"
+		Arch = archVersion
 
 		expected := version.Version{
 			Canonical: "v1.1.1",
@@ -36,13 +44,13 @@ func TestNew(t *testing.T) {
 	})
 	t.Run("no tag", func(t *testing.T) {
 		// to avoid flaky tests, set the values
-		Go = "go1.20.7"
-		OS = "darwin"
+		Go = goVersion
+		OS = osVersion
 		Compiler = "gc"
 		Tag = ""
 		Commit = "000"
 		Date = "111"
-		Arch = "arm64"
+		Arch = archVersion
 
 		expected := version.Version{
 			Canonical: "v0.0.0",
@@ -59,13 +67,13 @@ func TestNew(t *testing.T) {
 	})
 	t.Run("invalid tag", func(t *testing.T) {
 		// to avoid flaky tests, set the values
-		Go = "go1.20.7"
-		OS = "darwin"
+		Go = goVersion
+		OS = osVersion
 		Compiler = "gc"
 		Tag = "something"
 		Commit = "000"
 		Date = "111"
-		Arch = "arm64"
+		Arch = archVersion
 
 		expected := version.Version{
 			Canonical: "something",


### PR DESCRIPTION
I copied the config from https://github.com/go-vela/vela-docker/blob/main/.golangci.yml, and removed the plugins that are no longer included with [golangci-lint v2](https://golangci-lint.run/usage/configuration/#linters-configuration).

There was some interface, type, and package comments that were required, so I've added it to get it to pass the linter.